### PR TITLE
fix wrong calls filter because sessionId is same when call self

### DIFF
--- a/src/lib/callLogHelpers.js
+++ b/src/lib/callLogHelpers.js
@@ -61,6 +61,13 @@ export function isIntermediateCall(call = {}) {
   return call.terminationType === terminationTypes.intermediate;
 }
 
+export function isSelfCall(call = {}) {
+  if (call.to && call.from) {
+    return call.to.phoneNumber === call.from.phoneNumber;
+  }
+  return false;
+}
+
 /* sort functions */
 
 export function sortBySessionId(a, b) {
@@ -211,6 +218,26 @@ export function removeDuplicateIntermediateCalls(calls) {
       resultCalls.push(call);
     } else if (!isIntermediate) {
       indexMap[call.sessionId].isIntermediate = false;
+      resultCalls[indexMap[call.sessionId].index] = call;
+    }
+  });
+  return resultCalls;
+}
+
+// there are two active calls with same sessionId when user call self.
+export function removeDuplicateSelfCalls(calls) {
+  const resultCalls = [];
+  const indexMap = {};
+  calls.forEach((call) => {
+    const isSelf = isSelfCall(call);
+    if (!indexMap[call.sessionId]) {
+      indexMap[call.sessionid] = {
+        index: resultCalls.length,
+        isSelf,
+      };
+      resultCalls.push(call);
+    } else if (!isSelf) {
+      indexMap[call.sessionId].isSelf = false;
       resultCalls[indexMap[call.sessionId].index] = call;
     }
   });

--- a/src/modules/CallLogger/index.js
+++ b/src/modules/CallLogger/index.js
@@ -1,6 +1,10 @@
 import LoggerBase from '../../lib/LoggerBase';
 import ensureExist from '../../lib/ensureExist';
-import { isRinging, isInbound } from '../../lib/callLogHelpers';
+import {
+  isRinging,
+  isInbound,
+  removeDuplicateSelfCalls,
+} from '../../lib/callLogHelpers';
 import actionTypes from './actionTypes';
 import getDataReducer from './getDataReducer';
 import proxify from '../../lib/proxy/proxify';
@@ -158,9 +162,9 @@ export default class CallLogger extends LoggerBase {
           null;
 
         let toEntity = null;
-        if(toMatches && toMatches.length === 1) {
+        if (toMatches && toMatches.length === 1) {
           toEntity = toMatches[0];
-        }else if(toMatches && toMatches.length > 1 && toNumberEntity !== '') {
+        } else if(toMatches && toMatches.length > 1 && toNumberEntity !== '') {
           toEntity = toMatches.find(match =>
             toNumberEntity === match.id
           );
@@ -201,7 +205,7 @@ export default class CallLogger extends LoggerBase {
         ) || [];
         this._lastProcessedCalls = this._callMonitor.calls;
 
-        this._lastProcessedCalls.forEach((call) => {
+        removeDuplicateSelfCalls(this._lastProcessedCalls).forEach((call) => {
           const oldCallIndex = oldCalls.findIndex(item => item.sessionId === call.sessionId);
 
           if (oldCallIndex === -1) {

--- a/src/modules/DetailedPresence/getDetailedPresenceReducer.js
+++ b/src/modules/DetailedPresence/getDetailedPresenceReducer.js
@@ -19,7 +19,13 @@ export function getDataReducer(types) {
   const removeIntermediateCall = R.reduce((result, activeCall) => {
     if (
       !isIntermediateCall(activeCall) &&
-      !R.find(item => item.sessionId === activeCall.sessionId, result)
+      !R.find(
+        item => (
+          item.sessionId === activeCall.sessionId &&
+          item.direction === activeCall.direction
+        ),
+        result
+      )
     ) {
       result.push(activeCall);
     }


### PR DESCRIPTION
When use call self, the session id is same.
It will not influence ringout calls. Because the two legs of ringout calls's session id is different.